### PR TITLE
Removed horizontal scroll bar

### DIFF
--- a/src/css/02-base/_layout.scss
+++ b/src/css/02-base/_layout.scss
@@ -10,7 +10,6 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  width: 100vw;
   font-display: swap;
 }
 


### PR DESCRIPTION
Having `width: 100vw` on a block element is not necessary, as they span the entire width of the screen anyway. I found that this was the reason the website had the horizontal scrollbar, which some people find annoying (me included, hence this PR xD)

![image](https://github.com/mbarker84/humane-web-manifesto/assets/65856786/45099111-7d68-4d70-af0d-f863d3fb5ffb)

The reason I suspect this behavior happens is because `100vw` does not account for the vertical scrollbar's width, hence the difference that lead to the horizontal scrollbar.
