### PR TITLE
Remove `width` property from `body` element

### DIFF
--- a/src/css/02-base/_layout.scss
+++ b/src/css/02-base/_layout.scss
@@ -10,7 +10,6 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  width: 100vw;
   font-display: swap;
 }
 


### PR DESCRIPTION
In browsers (excluding Firefox), this property adds a horizontal scrollbar. It is not needed as there is no horizontal content overflow.

### Motivation to propose the changes

1. **It makes the UI weird:** "The use of horizontal scrolling has a high interaction cost. In UX and UI terms, this means that it requires much more thinking and action on the user's behalf to promote engagement. When a user visits a website with strict vertical navigation, there's no additional effort required to learn more about the information presented." - [Mailchimp](https://mailchimp.com/resources/horizontal-scrolling/)
2. **It's a browser bug:** "Currently all browsers but Firefox incorrectly consider 100vw to be the entire page width, including vertical scroll bar, which can [cause a horizontal scroll bar](https://codepen.io/CiTA/pen/zYBmYBJ) when overflow: auto is set." - [Can I use](https://caniuse.com/?search=viewport%20units) (check the known issues section)